### PR TITLE
Directly inform Audio HAL regarding SCO state change

### DIFF
--- a/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
+++ b/src/com/android/bluetooth/hfp/HeadsetStateMachine.java
@@ -312,6 +312,7 @@ final class HeadsetStateMachine extends StateMachine {
         if (DBG) if (DBG) Log.d(TAG, "Enter doQuit()");
         int size = 0;
         if (mAudioManager != null) {
+             mAudioManager.setParameters("BT_SCO=off");
              mAudioManager.setBluetoothScoOn(false);
         }
         if (mActiveScoDevice != null && !mPhoneState.getIsCsCall()) {
@@ -336,6 +337,7 @@ final class HeadsetStateMachine extends StateMachine {
     public void cleanup() {
         if (DBG) if (DBG) Log.d(TAG, "Enter cleanup()");
         if (mAudioManager != null) {
+             mAudioManager.setParameters("BT_SCO=off");
              mAudioManager.setBluetoothScoOn(false);
         }
         if (mPhoneProxy != null) {
@@ -1279,6 +1281,8 @@ final class HeadsetStateMachine extends StateMachine {
                     // TODO(BT) should I save the state for next broadcast as the prevState?
                     mAudioState = BluetoothHeadset.STATE_AUDIO_CONNECTED;
                     setAudioParameters(device); /*Set proper Audio Paramters.*/
+
+                    mAudioManager.setParameters("BT_SCO=on");
                     mAudioManager.setBluetoothScoOn(true);
                     broadcastAudioState(device, BluetoothHeadset.STATE_AUDIO_CONNECTED,
                                         BluetoothHeadset.STATE_AUDIO_CONNECTING);
@@ -1785,9 +1789,11 @@ final class HeadsetStateMachine extends StateMachine {
                         if (mAudioManager.isSpeakerphoneOn()) {
                             // User option might be speaker as sco disconnection
                             // is delayed setting back the speaker option.
+                            mAudioManager.setParameters("BT_SCO=off");
                             mAudioManager.setBluetoothScoOn(false);
                             mAudioManager.setSpeakerphoneOn(true);
                         } else {
+                            mAudioManager.setParameters("BT_SCO=off");
                             mAudioManager.setBluetoothScoOn(false);
                         }
                         if (mA2dpSuspend) {
@@ -2321,6 +2327,7 @@ final class HeadsetStateMachine extends StateMachine {
                     }
                     mAudioState = BluetoothHeadset.STATE_AUDIO_CONNECTED;
                     setAudioParameters(device); /* Set proper Audio Parameters. */
+                    mAudioManager.setParameters("BT_SCO=on");
                     mAudioManager.setBluetoothScoOn(true);
                     mActiveScoDevice = device;
                     broadcastAudioState(device, BluetoothHeadset.STATE_AUDIO_CONNECTED,
@@ -2346,9 +2353,11 @@ final class HeadsetStateMachine extends StateMachine {
                     if (mAudioManager.isSpeakerphoneOn()) {
                         // User option might be speaker as sco disconnection
                         // is delayed setting back the speaker option.
+                        mAudioManager.setParameters("BT_SCO=off");
                         mAudioManager.setBluetoothScoOn(false);
                         mAudioManager.setSpeakerphoneOn(true);
                     } else {
+                        mAudioManager.setParameters("BT_SCO=off");
                         mAudioManager.setBluetoothScoOn(false);
                     }
                         if (mA2dpSuspend) {


### PR DESCRIPTION
Directly inform Audio HAL regarding SCO state changes
by bypassing blocking frameworks calls to prioritize
cleanup and init activities to other ones.

CRs-Fixed: 2048547
Change-Id: I16a1081ba5ae510ef3d05a10b12377716f2681dc